### PR TITLE
Remove tag prefix requirement from resourcecollection translator

### DIFF
--- a/aws-devopsguru-resourcecollection/src/main/java/software/amazon/devopsguru/resourcecollection/Translator.java
+++ b/aws-devopsguru-resourcecollection/src/main/java/software/amazon/devopsguru/resourcecollection/Translator.java
@@ -52,9 +52,8 @@ public class Translator {
             TagCollection tagCollection = tags.get(0);
             if (tagCollection.getAppBoundaryKey() == null
                     || tagCollection.getTagValues() == null
-                    || tagCollection.getTagValues().isEmpty()
-                    || !tagCollection.getAppBoundaryKey().toLowerCase().startsWith("devops-guru-")) {
-                throw new CfnInvalidRequestException("Invalid AppBoundaryKey & TagValues, need to start with DevOps Guru prefix");
+                    || tagCollection.getTagValues().isEmpty()) {
+                throw new CfnInvalidRequestException("Invalid AppBoundaryKey or TagValues");
             }
             if (tagCollection.getTagValues().contains("*") && tagCollection.getTagValues().size() > 1) {
                 throw new CfnInvalidRequestException("Star selection can only be used in isolation");


### PR DESCRIPTION
*Description of changes:*
Remove tag prefix requirement from ResourceCollection translator. Allows the DevOps Guru service to determine the requirements vs the CFN Handler.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
